### PR TITLE
scripts: fix opening a new windows on finding

### DIFF
--- a/scripts/findArm64Dts.sh
+++ b/scripts/findArm64Dts.sh
@@ -7,7 +7,7 @@ FILE=$(find $1/arch/arm64/boot/dts/ -name "$2")
 
 if [ -f "$FILE" ]; then
 	echo "Opening 📜 (Embedded Linux Dev)"
-	eval "$3 $FILE"
+	eval "$3 -r $FILE"
 else
 	echo "Not found $2 😢 (Embedded Linux Dev)" 1>&2
 	exit 42

--- a/scripts/findArmDts.sh
+++ b/scripts/findArmDts.sh
@@ -6,7 +6,7 @@ echo "Searching 🏃 (Embedded Linux Dev)"
 FILE=$1/arch/arm/boot/dts/$2
 if [ -f "$FILE" ]; then
 	echo "Opening 📜 (Embedded Linux Dev)"
-	eval "$3 $FILE"
+	eval "$3 -r $FILE"
 else
 	echo "Not found $FILE 😢 (Embedded Linux Dev)" 1>&2
 	exit 42

--- a/scripts/findDeviceTreeDoc.sh
+++ b/scripts/findDeviceTreeDoc.sh
@@ -9,7 +9,7 @@ fileList=(${grepRet//:/ })
 # open
 if [ "$fileList" != "" ]; then
 	echo "Opening 📜 (Embedded Linux Dev)"
-	eval "$3 $fileList"
+	eval "$3 -r $fileList"
 else
 	echo "Not found match for $2 😢 (Embedded Linux Dev)" 1>&2
 	exit 42

--- a/scripts/findDeviceTreeMatch.sh
+++ b/scripts/findDeviceTreeMatch.sh
@@ -9,7 +9,7 @@ fileList=(${grepRet//:/ })
 # open
 if [ "$fileList" != "" ]; then
 	echo "Opening 📜 (Embedded Linux Dev)"
-	eval "$3 $fileList"
+	eval "$3 -r $fileList"
 else
 	echo "Not found match for $2 😢 (Embedded Linux Dev)" 1>&2
 	exit 42

--- a/scripts/findLinuxInclude.sh
+++ b/scripts/findLinuxInclude.sh
@@ -6,7 +6,7 @@ echo "Searching 🏃 (Embedded Linux Dev)"
 FILE=$1/include/$2
 if [ -f "$FILE" ]; then
 	echo "Opening 📜 (Embedded Linux Dev)"
-	eval "$3 $FILE"
+	eval "$3 -r $FILE"
 else
 	echo "Not found $FILE 😢 (Embedded Linux Dev)" 1>&2
 	exit 42


### PR DESCRIPTION
Problem are occur with "Remote SSH" and "code-server"

for Remote SSH
when searching linux kernel header file , for example <linux/netpoll.h>, extension will open a new windows with only this file, add option "-r" can prevent this.

for code-server
![image](https://user-images.githubusercontent.com/73207484/201508616-2c3466bd-a742-4ed6-aeed-7a24c9f96ac6.png)

the available command is **code-server** instead of code , I try to add

> LinuxNativeCommands.ts:17

``` 
else if(vscode.env.appHost === 'server-distro') {
	this.insider = "code-server";
} 
```

it will debug success but build fail